### PR TITLE
Fix typo building rocksdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,9 @@ Quick install for debian/ubuntu like linux distributions.
     $ apt-get install build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev
     $ git clone https://github.com/facebook/rocksdb.git
     $ cd rocksdb
-    $ make build && cd build
+    $ mkdir build && cd build
     $ cmake ..
+    $ make
     $ export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:`pwd`/../include
     $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`
     $ export LIBRARY_PATH=${LIBRARY_PATH}:`pwd`


### PR DESCRIPTION
Updated installation steps as they are on read the docs http://python-rocksdb.readthedocs.io/en/latest/installation.html